### PR TITLE
prerequisite on node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Any content produced by NEAR, or developer resources that NEAR provides, are for
 
 ## Usage
 
+## Prerequisites:
+
+- Current version of [Node.js](https://nodejs.org/) <=v14.18.3
+
 ### Getting started
 
 1. clone this repo to a local folder

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Any content produced by NEAR, or developer resources that NEAR provides, are for
 
 ## Usage
 
-## Prerequisites:
+### Prerequisites:
 
 - Current version of [Node.js](https://nodejs.org/) <=v14.18.3
 


### PR DESCRIPTION
in order to avoid error “.../node: bad option: –experimental-wasm-bigint” when executing yarn test, the node version must be <= 14.18.3